### PR TITLE
Add heartbeat status record and rename namespace to app.avaast

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,21 @@
 # Required: DID of the account whose app view records to watch
-AVAAS_WATCH_DID=did:plc:your-did-here
+AVAAST_WATCH_DID=did:plc:your-did-here
 
 # Optional: PDS endpoint (auto-resolved from DID if not set)
 # When using docker compose, this is set automatically to the local PDS
-AVAAS_PDS_ENDPOINT=
+AVAAST_PDS_ENDPOINT=
 
 # Optional: Custom hostname for the app view
-AVAAS_HOSTNAME=
+AVAAST_HOSTNAME=
+
+# Optional: Node ID for this controller instance (enables heartbeat)
+AVAAST_NODE_ID=
+
+# Optional: App password for writing heartbeat status records to PDS
+AVAAST_APP_PASSWORD=
+
+# Optional: Heartbeat interval in milliseconds (default: 30000)
+AVAAST_HEARTBEAT_INTERVAL_MS=
 
 # ---- Local PDS configuration ----
 # Hostname the PDS identifies as (localhost for local dev)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ docker compose up -d pds jetstream
 # 3. Build all packages
 pnpm build
 
-# 4. Start AVaaSt (after setting AVAAS_WATCH_DID in .env)
+# 4. Start AVaaSt (after setting AVAAST_WATCH_DID in .env)
 pnpm --filter @avaast/cli start
 ```
 
@@ -82,15 +82,18 @@ Environment variables override file values.
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `AVAAS_WATCH_DID` | Yes | — | DID of the account whose `app.avaast.*` records to watch |
-| `AVAAS_PDS_ENDPOINT` | No | auto-resolved | PDS endpoint URL (resolved from DID if omitted) |
-| `AVAAS_WATCH_RKEY` | No | `self` | Record key for the appView record |
-| `AVAAS_PORT` | No | `3000` | Gateway HTTP port |
-| `AVAAS_CONTROLLER_PORT` | No | `3001` | Controller HTTP port |
-| `AVAAS_HOSTNAME` | No | — | Custom hostname for the app view |
-| `AVAAS_MAX_PROCESSES` | No | `4` | Max concurrent function sandbox processes (1–32) |
-| `AVAAS_FUNCTION_TIMEOUT` | No | `30000` | Function execution timeout in ms (100–30000) |
-| `AVAAS_FUNCTION_MEMORY` | No | `128` | Function memory limit in MB (64–1024) |
+| `AVAAST_WATCH_DID` | Yes | — | DID of the account whose `app.avaast.*` records to watch |
+| `AVAAST_PDS_ENDPOINT` | No | auto-resolved | PDS endpoint URL (resolved from DID if omitted) |
+| `AVAAST_WATCH_RKEY` | No | `self` | Record key for the appView record |
+| `AVAAST_PORT` | No | `3000` | Gateway HTTP port |
+| `AVAAST_CONTROLLER_PORT` | No | `3001` | Controller HTTP port |
+| `AVAAST_HOSTNAME` | No | — | Custom hostname for the app view |
+| `AVAAST_NODE_ID` | No | — | Node ID for this controller instance (enables heartbeat) |
+| `AVAAST_APP_PASSWORD` | No | — | App password for writing heartbeat records to PDS |
+| `AVAAST_HEARTBEAT_INTERVAL_MS` | No | `30000` | Heartbeat interval in milliseconds |
+| `AVAAST_MAX_PROCESSES` | No | `4` | Max concurrent function sandbox processes (1–32) |
+| `AVAAST_FUNCTION_TIMEOUT` | No | `30000` | Function execution timeout in ms (100–30000) |
+| `AVAAST_FUNCTION_MEMORY` | No | `128` | Function memory limit in MB (64–1024) |
 
 ### Local PDS Variables (for Docker Compose dev setup)
 
@@ -284,13 +287,14 @@ AVaaSt defines its own lexicons under the `app.avaast.*` namespace:
 
 | Lexicon | File | Description |
 |---------|------|-------------|
-| `app.avaast.defs` | `lexicons/dev/avaas/defs.json` | Shared type definitions (expressions, queries, schemas) |
-| `app.avaast.computed` | `lexicons/dev/avaas/computed.json` | Computed view records |
-| `app.avaast.function` | `lexicons/dev/avaas/function.json` | Serverless function records |
-| `app.avaast.searchIndex` | `lexicons/dev/avaas/searchIndex.json` | Search index definitions |
-| `app.avaast.subscription` | `lexicons/dev/avaas/subscription.json` | Subscription definitions |
-| `app.avaast.deploy` | `lexicons/dev/avaas/deploy.json` | Deploy bundles |
-| `app.avaast.appView` | `lexicons/dev/avaas/appView.json` | App view service records |
+| `app.avaast.defs` | `lexicons/app/avaast/defs.json` | Shared type definitions (expressions, queries, schemas) |
+| `app.avaast.computed` | `lexicons/app/avaast/computed.json` | Computed view records |
+| `app.avaast.function` | `lexicons/app/avaast/function.json` | Serverless function records |
+| `app.avaast.searchIndex` | `lexicons/app/avaast/searchIndex.json` | Search index definitions |
+| `app.avaast.subscription` | `lexicons/app/avaast/subscription.json` | Subscription definitions |
+| `app.avaast.deploy` | `lexicons/app/avaast/deploy.json` | Deploy bundles |
+| `app.avaast.appView` | `lexicons/app/avaast/appView.json` | App view service records |
+| `app.avaast.status` | `lexicons/app/avaast/status.json` | Heartbeat/status records |
 
 App-specific lexicons (like `chat.pirate.avast` and `chat.pirate.aye`) live alongside
 the AVaaSt lexicons in the `lexicons/` directory.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - AVAAS_CONTROLLER_URL=http://controller:3001
+      - AVAAST_CONTROLLER_URL=http://controller:3001
     depends_on:
       - controller
 
@@ -66,11 +66,11 @@ services:
     ports:
       - "3001:3001"
     environment:
-      - AVAAS_WATCH_DID=${AVAAS_WATCH_DID}
-      - AVAAS_PDS_ENDPOINT=http://pds:2583
-      - AVAAS_JETSTREAM_URL=ws://jetstream:6008/subscribe
+      - AVAAST_WATCH_DID=${AVAAST_WATCH_DID}
+      - AVAAST_PDS_ENDPOINT=http://pds:2583
+      - AVAAST_JETSTREAM_URL=ws://jetstream:6008/subscribe
     volumes:
-      - avaas-data:/data
+      - avaast-data:/data
     depends_on:
       - deno-runtime
       - pds
@@ -79,10 +79,10 @@ services:
   deno-runtime:
     image: denoland/deno:latest
     volumes:
-      - avaas-functions:/functions
+      - avaast-functions:/functions
 
 volumes:
-  avaas-data:
-  avaas-functions:
+  avaast-data:
+  avaast-functions:
   pds-data:
   jetstream-data:

--- a/lexicons/app/avaast/appView.json
+++ b/lexicons/app/avaast/appView.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "dev.avaas.appView",
+  "id": "app.avaast.appView",
   "description": "An app view record that represents a running service endpoint with traffic routing across deployments.",
   "defs": {
     "main": {
@@ -27,7 +27,7 @@
             "type": "array",
             "items": {
               "type": "ref",
-              "ref": "dev.avaas.defs#trafficRule"
+              "ref": "app.avaast.defs#trafficRule"
             }
           },
           "status": {

--- a/lexicons/app/avaast/computed.json
+++ b/lexicons/app/avaast/computed.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "dev.avaas.computed",
+  "id": "app.avaast.computed",
   "description": "A computed view record that defines a declarative query over AT Protocol collections with a typed output schema.",
   "defs": {
     "main": {
@@ -21,20 +21,20 @@
           },
           "query": {
             "type": "ref",
-            "ref": "dev.avaas.defs#query"
+            "ref": "app.avaast.defs#query"
           },
           "outputSchema": {
             "type": "array",
             "items": {
               "type": "ref",
-              "ref": "dev.avaas.defs#outputField"
+              "ref": "app.avaast.defs#outputField"
             }
           },
           "parameters": {
             "type": "array",
             "items": {
               "type": "ref",
-              "ref": "dev.avaas.defs#queryParameter"
+              "ref": "app.avaast.defs#queryParameter"
             }
           },
           "cacheTtl": {

--- a/lexicons/app/avaast/defs.json
+++ b/lexicons/app/avaast/defs.json
@@ -1,7 +1,7 @@
 {
   "lexicon": 1,
-  "id": "dev.avaas.defs",
-  "description": "Shared type definitions for the AVaaS platform.",
+  "id": "app.avaast.defs",
+  "description": "Shared type definitions for the AVaaSt platform.",
   "defs": {
     "resourceRef": {
       "type": "object",

--- a/lexicons/app/avaast/deploy.json
+++ b/lexicons/app/avaast/deploy.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "dev.avaas.deploy",
+  "id": "app.avaast.deploy",
   "description": "A deploy record that bundles a set of resource endpoints into a single versioned deployment unit.",
   "defs": {
     "main": {
@@ -47,7 +47,7 @@
         },
         "ref": {
           "type": "ref",
-          "ref": "dev.avaas.defs#resourceRef"
+          "ref": "app.avaast.defs#resourceRef"
         }
       }
     }

--- a/lexicons/app/avaast/function.json
+++ b/lexicons/app/avaast/function.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "dev.avaas.function",
+  "id": "app.avaast.function",
   "description": "A serverless function record that runs user-supplied code with declared inputs, outputs, and dependencies.",
   "defs": {
     "main": {
@@ -37,21 +37,21 @@
             "type": "array",
             "items": {
               "type": "ref",
-              "ref": "dev.avaas.defs#namedFieldSchema"
+              "ref": "app.avaast.defs#namedFieldSchema"
             }
           },
           "outputSchema": {
             "type": "array",
             "items": {
               "type": "ref",
-              "ref": "dev.avaas.defs#namedFieldSchema"
+              "ref": "app.avaast.defs#namedFieldSchema"
             }
           },
           "dependencies": {
             "type": "array",
             "items": {
               "type": "ref",
-              "ref": "dev.avaas.defs#dependency"
+              "ref": "app.avaast.defs#dependency"
             }
           },
           "runtime": {

--- a/lexicons/app/avaast/searchIndex.json
+++ b/lexicons/app/avaast/searchIndex.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "dev.avaas.searchIndex",
+  "id": "app.avaast.searchIndex",
   "description": "A search index record that defines full-text and structured search over AT Protocol collection data.",
   "defs": {
     "main": {
@@ -21,7 +21,7 @@
           },
           "source": {
             "type": "ref",
-            "ref": "dev.avaas.defs#source"
+            "ref": "app.avaast.defs#source"
           },
           "fields": {
             "type": "array",
@@ -41,7 +41,7 @@
             "type": "array",
             "items": {
               "type": "ref",
-              "ref": "dev.avaas.defs#outputField"
+              "ref": "app.avaast.defs#outputField"
             }
           },
           "createdAt": {

--- a/lexicons/app/avaast/status.json
+++ b/lexicons/app/avaast/status.json
@@ -1,0 +1,47 @@
+{
+  "lexicon": 1,
+  "id": "app.avaast.status",
+  "description": "A status/heartbeat record written by a controller node to indicate liveness and current state.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A status record updated in place via putRecord with rkey = nodeId.",
+      "key": "any",
+      "record": {
+        "type": "object",
+        "required": ["nodeId", "nextHeartbeatAt", "createdAt"],
+        "properties": {
+          "nodeId": {
+            "type": "string",
+            "maxLength": 256
+          },
+          "nextHeartbeatAt": {
+            "type": "string",
+            "format": "datetime"
+          },
+          "startedAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "When this controller node started."
+          },
+          "version": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "Software version of the controller."
+          },
+          "appViewCids": {
+            "type": "array",
+            "description": "CIDs of the app view records this node has observed. Nodes reaching agreement will report the same set.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime"
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app/avaast/subscription.json
+++ b/lexicons/app/avaast/subscription.json
@@ -1,6 +1,6 @@
 {
   "lexicon": 1,
-  "id": "dev.avaas.subscription",
+  "id": "app.avaast.subscription",
   "description": "A reactive subscription record that watches a data source and emits matching records in real time.",
   "defs": {
     "main": {
@@ -21,31 +21,31 @@
           },
           "source": {
             "type": "ref",
-            "ref": "dev.avaas.defs#source"
+            "ref": "app.avaast.defs#source"
           },
           "filter": {
             "type": "ref",
-            "ref": "dev.avaas.defs#expression"
+            "ref": "app.avaast.defs#expression"
           },
           "fields": {
             "type": "array",
             "items": {
               "type": "ref",
-              "ref": "dev.avaas.defs#selectField"
+              "ref": "app.avaast.defs#selectField"
             }
           },
           "parameters": {
             "type": "array",
             "items": {
               "type": "ref",
-              "ref": "dev.avaas.defs#queryParameter"
+              "ref": "app.avaast.defs#queryParameter"
             }
           },
           "outputSchema": {
             "type": "array",
             "items": {
               "type": "ref",
-              "ref": "dev.avaas.defs#outputField"
+              "ref": "app.avaast.defs#outputField"
             }
           },
           "createdAt": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -84,7 +84,7 @@ resolved settings or error messages.
 The CLI loads configuration from three sources (later sources override earlier):
 
 1. **Config file** — `avaast.json` in the working directory, or the path given with `-c`
-2. **Environment variables** — `AVAAS_WATCH_DID`, `AVAAS_PDS_ENDPOINT`, `AVAAS_PORT`, etc.
+2. **Environment variables** — `AVAAST_WATCH_DID`, `AVAAST_PDS_ENDPOINT`, `AVAAST_PORT`, etc.
 3. **Zod validation** — applies defaults and validates constraints
 
 See the [root README](../../README.md#configuration) for the full variable reference.

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -9,7 +9,7 @@ export async function startCommand(config: Config, options: { logLevel?: string 
   }
 
   logger.info('Starting AVaaSt...');
-  logger.info(`Watching DID: ${config.avaas.watchDid}`);
+  logger.info(`Watching DID: ${config.avaast.watchDid}`);
   logger.info(`Gateway port: ${config.server.port}`);
   logger.info(`Controller port: ${config.server.controllerPort}`);
 

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -6,9 +6,9 @@ export function validateCommand(configPath?: string): void {
     console.log('Configuration is valid!');
     console.log('');
     console.log('Settings:');
-    console.log(`  Watch DID:        ${config.avaas.watchDid}`);
-    console.log(`  Watch rkey:       ${config.avaas.watchRkey}`);
-    console.log(`  PDS endpoint:     ${config.avaas.pdsEndpoint ?? '(auto-resolve)'}`);
+    console.log(`  Watch DID:        ${config.avaast.watchDid}`);
+    console.log(`  Watch rkey:       ${config.avaast.watchRkey}`);
+    console.log(`  PDS endpoint:     ${config.avaast.pdsEndpoint ?? '(auto-resolve)'}`);
     console.log(`  Gateway port:     ${config.server.port}`);
     console.log(`  Controller port:  ${config.server.controllerPort}`);
     console.log(`  Hostname:         ${config.server.hostname ?? '(none)'}`);

--- a/packages/cli/src/config-loader.ts
+++ b/packages/cli/src/config-loader.ts
@@ -21,52 +21,64 @@ export function loadConfig(configPath?: string): Config {
   }
 
   // 2. Build nested structure, applying env var overrides
-  const avaas = (raw.avaas ?? {}) as Record<string, unknown>;
+  const avaast = (raw.avaast ?? {}) as Record<string, unknown>;
   const server = (raw.server ?? {}) as Record<string, unknown>;
   const execution = (raw.execution ?? {}) as Record<string, unknown>;
 
-  // AVAAS_WATCH_DID -> avaas.watchDid
-  if (process.env.AVAAS_WATCH_DID) {
-    avaas.watchDid = process.env.AVAAS_WATCH_DID;
+  // AVAAST_WATCH_DID -> avaast.watchDid
+  if (process.env.AVAAST_WATCH_DID) {
+    avaast.watchDid = process.env.AVAAST_WATCH_DID;
   }
-  // AVAAS_WATCH_RKEY -> avaas.watchRkey (default "self")
-  if (process.env.AVAAS_WATCH_RKEY) {
-    avaas.watchRkey = process.env.AVAAS_WATCH_RKEY;
+  // AVAAST_WATCH_RKEY -> avaast.watchRkey (default "self")
+  if (process.env.AVAAST_WATCH_RKEY) {
+    avaast.watchRkey = process.env.AVAAST_WATCH_RKEY;
   }
-  // AVAAS_PDS_ENDPOINT -> avaas.pdsEndpoint
-  if (process.env.AVAAS_PDS_ENDPOINT) {
-    avaas.pdsEndpoint = process.env.AVAAS_PDS_ENDPOINT;
+  // AVAAST_PDS_ENDPOINT -> avaast.pdsEndpoint
+  if (process.env.AVAAST_PDS_ENDPOINT) {
+    avaast.pdsEndpoint = process.env.AVAAST_PDS_ENDPOINT;
+  }
+  // AVAAST_NODE_ID -> avaast.nodeId
+  if (process.env.AVAAST_NODE_ID) {
+    avaast.nodeId = process.env.AVAAST_NODE_ID;
+  }
+  // AVAAST_APP_PASSWORD -> avaast.appPassword
+  if (process.env.AVAAST_APP_PASSWORD) {
+    avaast.appPassword = process.env.AVAAST_APP_PASSWORD;
+  }
+  // AVAAST_HEARTBEAT_INTERVAL_MS -> avaast.heartbeatIntervalMs
+  if (process.env.AVAAST_HEARTBEAT_INTERVAL_MS) {
+    avaast.heartbeatIntervalMs = parseInt(process.env.AVAAST_HEARTBEAT_INTERVAL_MS, 10);
   }
 
-  // AVAAS_PORT -> server.port
-  if (process.env.AVAAS_PORT) {
-    server.port = parseInt(process.env.AVAAS_PORT, 10);
+  // AVAAST_PORT -> server.port
+  if (process.env.AVAAST_PORT) {
+    server.port = parseInt(process.env.AVAAST_PORT, 10);
   }
-  // AVAAS_CONTROLLER_PORT -> server.controllerPort
-  if (process.env.AVAAS_CONTROLLER_PORT) {
-    server.controllerPort = parseInt(process.env.AVAAS_CONTROLLER_PORT, 10);
+  // AVAAST_CONTROLLER_PORT -> server.controllerPort
+  if (process.env.AVAAST_CONTROLLER_PORT) {
+    server.controllerPort = parseInt(process.env.AVAAST_CONTROLLER_PORT, 10);
   }
-  // AVAAS_HOSTNAME -> server.hostname
-  if (process.env.AVAAS_HOSTNAME) {
-    server.hostname = process.env.AVAAS_HOSTNAME;
+  // AVAAST_HOSTNAME -> server.hostname
+  if (process.env.AVAAST_HOSTNAME) {
+    server.hostname = process.env.AVAAST_HOSTNAME;
   }
 
-  // AVAAS_MAX_PROCESSES -> execution.maxFunctionProcesses
-  if (process.env.AVAAS_MAX_PROCESSES) {
-    execution.maxFunctionProcesses = parseInt(process.env.AVAAS_MAX_PROCESSES, 10);
+  // AVAAST_MAX_PROCESSES -> execution.maxFunctionProcesses
+  if (process.env.AVAAST_MAX_PROCESSES) {
+    execution.maxFunctionProcesses = parseInt(process.env.AVAAST_MAX_PROCESSES, 10);
   }
-  // AVAAS_FUNCTION_TIMEOUT -> execution.functionTimeout
-  if (process.env.AVAAS_FUNCTION_TIMEOUT) {
-    execution.functionTimeout = parseInt(process.env.AVAAS_FUNCTION_TIMEOUT, 10);
+  // AVAAST_FUNCTION_TIMEOUT -> execution.functionTimeout
+  if (process.env.AVAAST_FUNCTION_TIMEOUT) {
+    execution.functionTimeout = parseInt(process.env.AVAAST_FUNCTION_TIMEOUT, 10);
   }
-  // AVAAS_FUNCTION_MEMORY -> execution.functionMemoryLimit
-  if (process.env.AVAAS_FUNCTION_MEMORY) {
-    execution.functionMemoryLimit = parseInt(process.env.AVAAS_FUNCTION_MEMORY, 10);
+  // AVAAST_FUNCTION_MEMORY -> execution.functionMemoryLimit
+  if (process.env.AVAAST_FUNCTION_MEMORY) {
+    execution.functionMemoryLimit = parseInt(process.env.AVAAST_FUNCTION_MEMORY, 10);
   }
 
   // 3. Validate with parseConfig (zod) and return typed Config
   return parseConfig({
-    avaas,
+    avaast,
     server,
     execution,
   });

--- a/packages/controller/src/__tests__/e2e/pirate-app.test.ts
+++ b/packages/controller/src/__tests__/e2e/pirate-app.test.ts
@@ -105,7 +105,7 @@ describe("Pirate App E2E", () => {
       "password123",
     );
 
-    // 2. Start Controller (connects to Jetstream, watches for dev.avaas.* records)
+    // 2. Start Controller (connects to Jetstream, watches for app.avaast.* records)
     controller = new Controller({
       pdsEndpoint: PDS_URL,
       watchDid: account.did,
@@ -125,14 +125,14 @@ describe("Pirate App E2E", () => {
     // Small delay to let Jetstream connection establish
     await new Promise((r) => setTimeout(r, 1000));
 
-    // 4. Write AVaaSt records to PDS — Jetstream delivers events → Controller
+    // 4. Write AVaaSt records to PDS — Jetstream delivers events -> Controller
 
-    // 4a. dev.avaas.computed — the pirate query definition
+    // 4a. app.avaast.computed — the pirate query definition
     const computedRef = await createRecord(
       PDS_URL,
       account.accessJwt,
       account.did,
-      "dev.avaas.computed",
+      "app.avaast.computed",
       {
         name: "chat.pirate.getAvasts",
         query: PIRATE_QUERY,
@@ -146,12 +146,12 @@ describe("Pirate App E2E", () => {
       },
     );
 
-    // 4b. dev.avaas.deploy — endpoint mapping
+    // 4b. app.avaast.deploy — endpoint mapping
     const deployRef = await createRecord(
       PDS_URL,
       account.accessJwt,
       account.did,
-      "dev.avaas.deploy",
+      "app.avaast.deploy",
       {
         endpoints: [
           {
@@ -164,12 +164,12 @@ describe("Pirate App E2E", () => {
       },
     );
 
-    // 4c. dev.avaas.appView — traffic rules
+    // 4c. app.avaast.appView — traffic rules
     await createRecord(
       PDS_URL,
       account.accessJwt,
       account.did,
-      "dev.avaas.appView",
+      "app.avaast.appView",
       {
         name: "pirate-app",
         trafficRules: [

--- a/packages/controller/src/changelog.ts
+++ b/packages/controller/src/changelog.ts
@@ -1,0 +1,124 @@
+import Database from "better-sqlite3";
+import { createLogger } from "@avaast/shared";
+import type { FirehoseEvent } from "./watcher/index.js";
+
+export interface ChangeLogEntry {
+  id: number;
+  collection: string;
+  rkey: string;
+  did: string;
+  eventType: string;
+  recordJson: string | null;
+  createdAt: string;
+}
+
+/**
+ * ChangeLog stores a timestamped event log of record mutations seen by the
+ * watcher. When the watcher sees a create/update/delete event it appends a
+ * snapshot here. Computed queries can read from the change log to get
+ * history over time.
+ *
+ * Uses WAL journal mode (same pattern as CursorStore).
+ */
+export class ChangeLog {
+  private db: Database.Database;
+  private logger = createLogger("changelog");
+  private insertStmt: Database.Statement;
+
+  constructor(dbPath: string) {
+    this.db = new Database(dbPath);
+    this.db.pragma("journal_mode = WAL");
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS changelog (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        collection TEXT NOT NULL,
+        rkey TEXT NOT NULL,
+        did TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        record_json TEXT,
+        created_at TEXT NOT NULL
+      )
+    `);
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_changelog_lookup
+        ON changelog(collection, did, created_at)
+    `);
+    this.insertStmt = this.db.prepare(
+      `INSERT INTO changelog (collection, rkey, did, event_type, record_json, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    );
+    this.logger.info(`ChangeLog initialized at ${dbPath}`);
+  }
+
+  append(event: FirehoseEvent): void {
+    const recordJson =
+      event.record != null ? JSON.stringify(event.record) : null;
+    this.insertStmt.run(
+      event.collection,
+      event.rkey,
+      event.did,
+      event.type,
+      recordJson,
+      new Date().toISOString(),
+    );
+  }
+
+  query(
+    collection: string,
+    options?: {
+      did?: string;
+      eventType?: string;
+      limit?: number;
+      afterDate?: string;
+    },
+  ): ChangeLogEntry[] {
+    const conditions: string[] = ["collection = ?"];
+    const params: unknown[] = [collection];
+
+    if (options?.did) {
+      conditions.push("did = ?");
+      params.push(options.did);
+    }
+    if (options?.eventType) {
+      conditions.push("event_type = ?");
+      params.push(options.eventType);
+    }
+    if (options?.afterDate) {
+      conditions.push("created_at > ?");
+      params.push(options.afterDate);
+    }
+
+    const limit = options?.limit ?? 100;
+    const sql = `SELECT id, collection, rkey, did, event_type, record_json, created_at
+                 FROM changelog
+                 WHERE ${conditions.join(" AND ")}
+                 ORDER BY created_at DESC
+                 LIMIT ?`;
+    params.push(limit);
+
+    const rows = this.db.prepare(sql).all(...params) as Array<{
+      id: number;
+      collection: string;
+      rkey: string;
+      did: string;
+      event_type: string;
+      record_json: string | null;
+      created_at: string;
+    }>;
+
+    return rows.map((r) => ({
+      id: r.id,
+      collection: r.collection,
+      rkey: r.rkey,
+      did: r.did,
+      eventType: r.event_type,
+      recordJson: r.record_json,
+      createdAt: r.created_at,
+    }));
+  }
+
+  close(): void {
+    this.db.close();
+    this.logger.info("ChangeLog closed");
+  }
+}

--- a/packages/controller/src/heartbeat.ts
+++ b/packages/controller/src/heartbeat.ts
@@ -1,0 +1,99 @@
+import { createLogger } from "@avaast/shared";
+import type { StatusRecord } from "@avaast/shared";
+import type { PdsClient } from "./pds-client.js";
+
+const DEFAULT_INTERVAL_MS = 30_000;
+const GRACE_FACTOR = 2;
+
+export interface HeartbeatOptions {
+  nodeId: string;
+  pdsClient: PdsClient;
+  intervalMs?: number;
+  /** Called each tick to get the CIDs of app view records this node has observed. */
+  getAppViewCids?: () => string[];
+  /** Software version string included in the status record. */
+  version?: string;
+}
+
+/**
+ * Heartbeat writes a status record to the PDS at a regular interval.
+ *
+ * Each tick calls `putRecord` for `app.avaast.status` at rkey = nodeId,
+ * setting `nextHeartbeatAt` to now + interval + grace so observers know
+ * when to expect the next heartbeat. The record includes the CIDs of
+ * app view records this node has observed, allowing observers to check
+ * whether nodes have reached agreement.
+ *
+ * Errors are logged but never crash the process.
+ */
+export class Heartbeat {
+  private logger = createLogger("heartbeat");
+  private nodeId: string;
+  private pdsClient: PdsClient;
+  private intervalMs: number;
+  private getAppViewCids: () => string[];
+  private version?: string;
+  private startedAt: string;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(options: HeartbeatOptions) {
+    this.nodeId = options.nodeId;
+    this.pdsClient = options.pdsClient;
+    this.intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.getAppViewCids = options.getAppViewCids ?? (() => []);
+    this.version = options.version;
+    this.startedAt = new Date().toISOString();
+  }
+
+  async start(): Promise<void> {
+    this.logger.info(
+      `Starting heartbeat for node ${this.nodeId} (interval: ${this.intervalMs}ms)`,
+    );
+    // Write initial heartbeat immediately
+    await this.tick();
+    // Then repeat at interval
+    this.timer = setInterval(() => {
+      this.tick().catch((err) => {
+        this.logger.error("Heartbeat tick failed", err);
+      });
+    }, this.intervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+      this.logger.info("Heartbeat stopped");
+    }
+  }
+
+  private async tick(): Promise<void> {
+    const now = new Date();
+    const nextHeartbeatAt = new Date(
+      now.getTime() + this.intervalMs + this.intervalMs * GRACE_FACTOR,
+    );
+
+    const appViewCids = this.getAppViewCids();
+    const record: StatusRecord = {
+      nodeId: this.nodeId,
+      nextHeartbeatAt: nextHeartbeatAt.toISOString(),
+      startedAt: this.startedAt,
+      version: this.version,
+      appViewCids: appViewCids.length > 0 ? appViewCids : undefined,
+      createdAt: now.toISOString(),
+    };
+
+    try {
+      await this.pdsClient.putRecord(
+        "app.avaast.status",
+        this.nodeId,
+        record,
+      );
+      this.logger.debug(
+        `Heartbeat written: nextHeartbeatAt=${record.nextHeartbeatAt}, appViewCids=${appViewCids.length}`,
+      );
+    } catch (err) {
+      this.logger.error("Failed to write heartbeat", err);
+    }
+  }
+}

--- a/packages/controller/src/pds-client.ts
+++ b/packages/controller/src/pds-client.ts
@@ -1,0 +1,127 @@
+import { createLogger } from "@avaast/shared";
+
+/**
+ * PdsClient handles authenticated communication with a PDS.
+ *
+ * Uses AT Protocol app passwords — revocable credentials created in PDS
+ * settings. Handles session creation, refresh, and auto-retry on 401.
+ */
+export class PdsClient {
+  private logger = createLogger("pds-client");
+  private pdsEndpoint: string;
+  private accessJwt: string | null = null;
+  private refreshJwt: string | null = null;
+  private did: string | null = null;
+
+  constructor(pdsEndpoint: string) {
+    this.pdsEndpoint = pdsEndpoint;
+  }
+
+  async createSession(
+    identifier: string,
+    appPassword: string,
+  ): Promise<void> {
+    const resp = await fetch(
+      `${this.pdsEndpoint}/xrpc/com.atproto.server.createSession`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ identifier, password: appPassword }),
+      },
+    );
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`createSession failed (${resp.status}): ${text}`);
+    }
+    const data = (await resp.json()) as {
+      accessJwt: string;
+      refreshJwt: string;
+      did: string;
+    };
+    this.accessJwt = data.accessJwt;
+    this.refreshJwt = data.refreshJwt;
+    this.did = data.did;
+    this.logger.info(`Session created for ${this.did}`);
+  }
+
+  async refreshSession(): Promise<void> {
+    if (!this.refreshJwt) {
+      throw new Error("No refresh token available");
+    }
+    const resp = await fetch(
+      `${this.pdsEndpoint}/xrpc/com.atproto.server.refreshSession`,
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${this.refreshJwt}` },
+      },
+    );
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`refreshSession failed (${resp.status}): ${text}`);
+    }
+    const data = (await resp.json()) as {
+      accessJwt: string;
+      refreshJwt: string;
+      did: string;
+    };
+    this.accessJwt = data.accessJwt;
+    this.refreshJwt = data.refreshJwt;
+    this.did = data.did;
+    this.logger.debug("Session refreshed");
+  }
+
+  async putRecord(
+    collection: string,
+    rkey: string,
+    record: unknown,
+  ): Promise<{ uri: string; cid: string }> {
+    if (!this.accessJwt || !this.did) {
+      throw new Error("Not authenticated — call createSession first");
+    }
+
+    const doRequest = async (): Promise<Response> => {
+      return fetch(
+        `${this.pdsEndpoint}/xrpc/com.atproto.repo.putRecord`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${this.accessJwt}`,
+          },
+          body: JSON.stringify({
+            repo: this.did,
+            collection,
+            rkey,
+            record,
+          }),
+        },
+      );
+    };
+
+    let resp = await doRequest();
+
+    // Auto-refresh on 401 and retry once
+    if (resp.status === 401) {
+      this.logger.debug("Got 401, attempting session refresh");
+      try {
+        await this.refreshSession();
+        resp = await doRequest();
+      } catch (refreshErr) {
+        throw new Error(
+          `putRecord failed after refresh attempt: ${refreshErr}`,
+        );
+      }
+    }
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`putRecord failed (${resp.status}): ${text}`);
+    }
+
+    return (await resp.json()) as { uri: string; cid: string };
+  }
+
+  getDid(): string | null {
+    return this.did;
+  }
+}

--- a/packages/controller/src/query/index.ts
+++ b/packages/controller/src/query/index.ts
@@ -6,4 +6,9 @@ export {
   type SourcePlan,
 } from "./planner.js";
 export { QueryCache } from "./cache.js";
-export { PdsDataSource, type DataSourceAdapter } from "./sources.js";
+export {
+  PdsDataSource,
+  ChangeLogDataSource,
+  RoutingDataSource,
+  type DataSourceAdapter,
+} from "./sources.js";

--- a/packages/controller/src/query/sources.ts
+++ b/packages/controller/src/query/sources.ts
@@ -1,5 +1,6 @@
 import { createLogger } from "@avaast/shared";
 import type { Source } from "@avaast/shared";
+import type { ChangeLog } from "../changelog.js";
 
 export interface DataSourceAdapter {
   fetchRecords(source: Source, did?: string): Promise<unknown[]>;
@@ -41,4 +42,98 @@ export class PdsDataSource implements DataSourceAdapter {
       _cid: r.cid,
     }));
   }
+}
+
+/**
+ * ChangeLogDataSource reads historical events from the ChangeLog SQLite table.
+ * Used for collections suffixed with `:updates` or `:deletes`.
+ */
+export class ChangeLogDataSource implements DataSourceAdapter {
+  private logger = createLogger("changelog-data-source");
+  private changeLog: ChangeLog;
+  private eventType: string;
+
+  constructor(changeLog: ChangeLog, eventType: string) {
+    this.changeLog = changeLog;
+    this.eventType = eventType;
+  }
+
+  async fetchRecords(source: Source, defaultDid?: string): Promise<unknown[]> {
+    const did = source.did ?? defaultDid;
+    this.logger.debug(
+      `Fetching changelog records: ${source.collection} (${this.eventType}) for ${did ?? "any"}`,
+    );
+
+    const eventTypes =
+      this.eventType === "updates" ? "create" : "delete";
+
+    const entries = this.changeLog.query(source.collection, {
+      did: did ?? undefined,
+      eventType: eventTypes,
+    });
+
+    return entries.map((entry) => {
+      const record =
+        entry.recordJson != null
+          ? (JSON.parse(entry.recordJson) as Record<string, unknown>)
+          : {};
+      return {
+        ...record,
+        _rkey: entry.rkey,
+        _did: entry.did,
+        _eventType: entry.eventType,
+        _createdAt: entry.createdAt,
+      };
+    });
+  }
+}
+
+/**
+ * RoutingDataSource parses the collection string and routes to the right
+ * data source:
+ *
+ * - `app.avaast.status` → PdsDataSource (current state via listRecords)
+ * - `app.avaast.status:updates` → ChangeLogDataSource (create + update events)
+ * - `app.avaast.status:deletes` → ChangeLogDataSource (delete events)
+ */
+export class RoutingDataSource implements DataSourceAdapter {
+  private pds: PdsDataSource;
+  private updatesSource: ChangeLogDataSource;
+  private deletesSource: ChangeLogDataSource;
+
+  constructor(pds: PdsDataSource, changeLog: ChangeLog) {
+    this.pds = pds;
+    this.updatesSource = new ChangeLogDataSource(changeLog, "updates");
+    this.deletesSource = new ChangeLogDataSource(changeLog, "deletes");
+  }
+
+  async fetchRecords(source: Source, defaultDid?: string): Promise<unknown[]> {
+    const { collection, suffix } = parseCollectionSuffix(source.collection);
+
+    // Build a source with the base collection (suffix stripped)
+    const baseSource: Source = { ...source, collection };
+
+    switch (suffix) {
+      case "updates":
+        return this.updatesSource.fetchRecords(baseSource, defaultDid);
+      case "deletes":
+        return this.deletesSource.fetchRecords(baseSource, defaultDid);
+      default:
+        return this.pds.fetchRecords(source, defaultDid);
+    }
+  }
+}
+
+function parseCollectionSuffix(collection: string): {
+  collection: string;
+  suffix: string | null;
+} {
+  const colonIdx = collection.lastIndexOf(":");
+  if (colonIdx === -1) {
+    return { collection, suffix: null };
+  }
+  return {
+    collection: collection.slice(0, colonIdx),
+    suffix: collection.slice(colonIdx + 1),
+  };
 }

--- a/packages/controller/src/watcher/index.ts
+++ b/packages/controller/src/watcher/index.ts
@@ -12,13 +12,14 @@ import { CursorStore } from "./cursor-store.js";
 export { FirehoseClient, Poller, PdsResolver, CursorStore, JetstreamClient };
 export type { FirehoseEvent, FirehoseEventHandler };
 
-const AVAAS_COLLECTIONS = [
-  "dev.avaas.computed",
-  "dev.avaas.function",
-  "dev.avaas.searchIndex",
-  "dev.avaas.subscription",
-  "dev.avaas.deploy",
-  "dev.avaas.appView",
+const AVAAST_COLLECTIONS = [
+  "app.avaast.computed",
+  "app.avaast.function",
+  "app.avaast.searchIndex",
+  "app.avaast.subscription",
+  "app.avaast.deploy",
+  "app.avaast.appView",
+  "app.avaast.status",
 ];
 
 export interface WatcherOptions {
@@ -31,7 +32,7 @@ export interface WatcherOptions {
   onError?: (error: Error) => void;
   /** Jetstream WebSocket URL. When set, Jetstream is used instead of firehose/poller. */
   jetstreamUrl?: string;
-  /** Extra collections to subscribe to via Jetstream (merged with AVAAS_COLLECTIONS). */
+  /** Extra collections to subscribe to via Jetstream (merged with AVAAST_COLLECTIONS). */
   extraCollections?: string[];
 }
 
@@ -100,7 +101,7 @@ export class Watcher {
 
   private startJetstream(): void {
     const allCollections = [
-      ...AVAAS_COLLECTIONS,
+      ...AVAAST_COLLECTIONS,
       ...(this.options.extraCollections ?? []),
     ];
     this.logger.info(
@@ -128,7 +129,7 @@ export class Watcher {
     this.firehose = new FirehoseClient({
       pdsEndpoint: this.options.pdsEndpoint,
       cursor,
-      collections: AVAAS_COLLECTIONS,
+      collections: AVAAST_COLLECTIONS,
       onEvent: (event) => {
         if (event.did === this.options.watchDid) {
           this.options.onEvent(event);
@@ -151,7 +152,7 @@ export class Watcher {
     this.poller = new Poller({
       pdsEndpoint: this.options.pdsEndpoint,
       did: this.options.watchDid,
-      collections: AVAAS_COLLECTIONS,
+      collections: AVAAST_COLLECTIONS,
       intervalMs: this.options.pollIntervalMs ?? 30000,
       onEvent: this.options.onEvent,
       onError: this.options.onError,

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -1,10 +1,13 @@
 import { z } from "zod";
 
 export const configSchema = z.object({
-  avaas: z.object({
+  avaast: z.object({
     watchDid: z.string().startsWith("did:"),
     watchRkey: z.string().default("self"),
     pdsEndpoint: z.string().url().optional(),
+    nodeId: z.string().optional(),
+    appPassword: z.string().optional(),
+    heartbeatIntervalMs: z.number().int().min(1000).default(30000),
   }),
   server: z.object({
     port: z.number().int().min(1).max(65535).default(3000),

--- a/packages/shared/src/types/lexicon.ts
+++ b/packages/shared/src/types/lexicon.ts
@@ -262,3 +262,12 @@ export interface AppViewRecord {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface StatusRecord {
+  nodeId: string;
+  nextHeartbeatAt: string;
+  startedAt?: string;
+  version?: string;
+  appViewCids?: string[];
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary

- **Namespace rename**: `dev.avaas` → `app.avaast` across all lexicons, source code, config keys (`avaas` → `avaast`), env vars (`AVAAS_*` → `AVAAST_*`), docker-compose volumes, and documentation
- **Heartbeat status record** (`app.avaast.status`): written by each controller node via `putRecord` at a configurable interval, includes `appViewCids` for cross-node agreement detection
- **ChangeLog infrastructure**: SQLite-backed event log fed by the watcher, with `ChangeLogDataSource` and `RoutingDataSource` enabling history queries via `collection:updates` / `collection:deletes` suffixes

## New files

| File | Purpose |
|------|---------|
| `lexicons/app/avaast/status.json` | Status/heartbeat lexicon (key type `any`, rkey = nodeId) |
| `packages/controller/src/pds-client.ts` | Authenticated PDS client with session refresh |
| `packages/controller/src/heartbeat.ts` | Interval-based status record writer |
| `packages/controller/src/changelog.ts` | SQLite change log store |

## Status record shape

```json
{
  "nodeId": "controller-east-1",
  "nextHeartbeatAt": "2026-02-14T12:01:00.000Z",
  "startedAt": "2026-02-14T11:00:00.000Z",
  "version": "0.0.1",
  "appViewCids": ["bafyabc123"],
  "createdAt": "2026-02-14T12:00:30.000Z"
}
```

## Test plan

- [ ] `pnpm build` and `pnpm typecheck` pass across all packages
- [ ] Controller with `AVAAST_APP_PASSWORD` + `AVAAST_NODE_ID` writes heartbeat on start, updates at interval
- [ ] Controller without app password starts normally (no heartbeat, changelog still works)
- [ ] Watcher events are captured in the changelog
- [ ] Queries using `collection:updates` / `collection:deletes` suffixes route to changelog
- [ ] Stop cleans up heartbeat timer and closes changelog db

🤖 Generated with [Claude Code](https://claude.com/claude-code)